### PR TITLE
refactor: 不要なmallocの除去と_byteswap_ushortの使用

### DIFF
--- a/bookmark.cpp
+++ b/bookmark.cpp
@@ -238,7 +238,6 @@ void SaveBookMark(void)
 	MENUITEMINFO mInfo;
 	int i;
 	int Cnt;
-	char *Buf;
 	char *Pos;
 	int Len;
 	char Tmp[BMARK_MARK_LEN + FMAX_PATH * 2 + BMARK_SEP_LEN + 1];
@@ -248,45 +247,41 @@ void SaveBookMark(void)
 	{
 		if((CurHost = AskCurrentHost()) != HOSTNUM_NOENTRY)
 		{
-			if((Buf = (char*)malloc(BOOKMARK_SIZE)) != NULL)
-			{
-				hMenu = GetSubMenu(GetMenu(GetMainHwnd()), BMARK_SUB_MENU);
+			char Buf[BOOKMARK_SIZE];
+			hMenu = GetSubMenu(GetMenu(GetMainHwnd()), BMARK_SUB_MENU);
 
-				Pos = Buf;
-				Len = 0;
-				Cnt = GetMenuItemCount(hMenu);
-				for(i = DEFAULT_BMARK_ITEM; i < Cnt; i++)
+			Pos = Buf;
+			Len = 0;
+			Cnt = GetMenuItemCount(hMenu);
+			for(i = DEFAULT_BMARK_ITEM; i < Cnt; i++)
+			{
+				mInfo.cbSize = sizeof(MENUITEMINFO);
+				mInfo.fMask = MIIM_TYPE;
+				mInfo.dwTypeData = Tmp;
+				mInfo.cch = FMAX_PATH;
+				if(GetMenuItemInfo(hMenu, i, TRUE, &mInfo) == TRUE)
 				{
-					mInfo.cbSize = sizeof(MENUITEMINFO);
-					mInfo.fMask = MIIM_TYPE;
-					mInfo.dwTypeData = Tmp;
-					mInfo.cch = FMAX_PATH;
-					if(GetMenuItemInfo(hMenu, i, TRUE, &mInfo) == TRUE)
+					if(Len + strlen(Tmp) + 2 <= BOOKMARK_SIZE)
 					{
-						if(Len + strlen(Tmp) + 2 <= BOOKMARK_SIZE)
-						{
-							strcpy(Pos, Tmp);
-							Pos += strlen(Tmp) + 1;
-							Len += (int)strlen(Tmp) + 1;
-						}
+						strcpy(Pos, Tmp);
+						Pos += strlen(Tmp) + 1;
+						Len += (int)strlen(Tmp) + 1;
 					}
 				}
-
-				if(Pos == Buf)
-				{
-					memset(Buf, NUL, 2);
-					Len = 2;
-				}
-				else
-				{
-					*Pos = NUL;
-					Len++;
-				}
-
-				SetHostBookMark(CurHost, Buf, Len);
-
-				free(Buf);
 			}
+
+			if(Pos == Buf)
+			{
+				memset(Buf, NUL, 2);
+				Len = 2;
+			}
+			else
+			{
+				*Pos = NUL;
+				Len++;
+			}
+
+			SetHostBookMark(CurHost, Buf, Len);
 		}
 	}
 	return;

--- a/filelist.cpp
+++ b/filelist.cpp
@@ -96,7 +96,13 @@ static int AskFilterStr(char *Fname, int Type);
 // 64ビット対応
 //static BOOL CALLBACK FilterWndProc(HWND hDlg, UINT iMessage, WPARAM wParam, LPARAM lParam);
 static INT_PTR CALLBACK FilterWndProc(HWND hDlg, UINT iMessage, WPARAM wParam, LPARAM lParam);
-static int atoi_n(const char *Str, int Len);
+template<std::size_t Len>
+static int atoi_n(const char *Str)
+{
+	char Tmp[Len] = {};
+	strncpy(Tmp, Str, Len);
+	return atoi(Tmp);
+}
 
 /*===== 外部参照 =====*/
 
@@ -4959,7 +4965,7 @@ static int ResolveFileInfo(char *Str, int ListType, char *Fname, LONGLONG *Size,
 
 			/* 時刻 */
 			FindField(Str, Buf, 2, NO);
-			sTime.wHour = atoi_n(Buf, 2);
+			sTime.wHour = atoi_n<2>(Buf);
 			sTime.wMinute = atoi(Buf+2);
 			sTime.wSecond = 0;
 			sTime.wMilliseconds = 0;
@@ -5197,12 +5203,12 @@ static int ResolveFileInfo(char *Str, int ListType, char *Fname, LONGLONG *Size,
 						}
 						else if(_stricmp(Name, "modify") == 0)
 						{
-							sTime.wYear = atoi_n(Value, 4);
-							sTime.wMonth = atoi_n(Value + 4, 2);
-							sTime.wDay = atoi_n(Value + 6, 2);
-							sTime.wHour = atoi_n(Value + 8, 2);
-							sTime.wMinute = atoi_n(Value + 10, 2);
-							sTime.wSecond = atoi_n(Value + 12, 2);
+							sTime.wYear = atoi_n<4>(Value);
+							sTime.wMonth = atoi_n<2>(Value + 4);
+							sTime.wDay = atoi_n<2>(Value + 6);
+							sTime.wHour = atoi_n<2>(Value + 8);
+							sTime.wMinute = atoi_n<2>(Value + 10);
+							sTime.wSecond = atoi_n<2>(Value + 12);
 							sTime.wMilliseconds = 0;
 							SystemTimeToFileTime(&sTime, Time);
 							// 時刻はGMT
@@ -6012,29 +6018,6 @@ static INT_PTR CALLBACK FilterWndProc(HWND hDlg, UINT iMessage, WPARAM wParam, L
 	}
 	return(FALSE);
 }
-
-
-
-
-
-static int atoi_n(const char *Str, int Len)
-{
-	char *Tmp;
-	int Ret;
-
-	Ret = 0;
-	if((Tmp = (char*)malloc(Len+1)) != NULL)
-	{
-		memset(Tmp, 0, Len+1);
-		strncpy(Tmp, Str, Len);
-		Ret = atoi(Tmp);
-		free(Tmp);
-	}
-	return(Ret);
-}
-
-
-
 
 // UTF-8対応
 // ファイル一覧から漢字コードを推測

--- a/mbswrapper.cpp
+++ b/mbswrapper.cpp
@@ -2262,32 +2262,32 @@ BOOL ChooseFontM(LPCHOOSEFONTA v0)
 	wchar_t* pw0 = NULL;
 	wchar_t* pw1 = NULL;
 	CHOOSEFONTW a0;
-	LOGFONTW* pwlf;
+	LOGFONTW wlf;
 START_ROUTINE
 	a0.lStructSize = sizeof(CHOOSEFONTW);
 	a0.hwndOwner = v0->hwndOwner;
 	a0.hDC = v0->hDC;
-	if(v0->lpLogFont && (pwlf = (LOGFONTW*)malloc(sizeof(LOGFONTW))))
+	if(v0->lpLogFont)
 	{
-		pwlf->lfHeight = v0->lpLogFont->lfHeight;
-		pwlf->lfWidth = v0->lpLogFont->lfWidth;
-		pwlf->lfEscapement = v0->lpLogFont->lfEscapement;
-		pwlf->lfOrientation = v0->lpLogFont->lfOrientation;
-		pwlf->lfWeight = v0->lpLogFont->lfWeight;
-		pwlf->lfItalic = v0->lpLogFont->lfItalic;
-		pwlf->lfUnderline = v0->lpLogFont->lfUnderline;
-		pwlf->lfStrikeOut = v0->lpLogFont->lfStrikeOut;
-		pwlf->lfCharSet = v0->lpLogFont->lfCharSet;
-		pwlf->lfOutPrecision = v0->lpLogFont->lfOutPrecision;
-		pwlf->lfClipPrecision = v0->lpLogFont->lfClipPrecision;
-		pwlf->lfQuality = v0->lpLogFont->lfQuality;
-		pwlf->lfPitchAndFamily = v0->lpLogFont->lfPitchAndFamily;
-		MtoW(pwlf->lfFaceName, LF_FACESIZE, v0->lpLogFont->lfFaceName, -1);
-		TerminateStringW(pwlf->lfFaceName, LF_FACESIZE);
+		wlf.lfHeight = v0->lpLogFont->lfHeight;
+		wlf.lfWidth = v0->lpLogFont->lfWidth;
+		wlf.lfEscapement = v0->lpLogFont->lfEscapement;
+		wlf.lfOrientation = v0->lpLogFont->lfOrientation;
+		wlf.lfWeight = v0->lpLogFont->lfWeight;
+		wlf.lfItalic = v0->lpLogFont->lfItalic;
+		wlf.lfUnderline = v0->lpLogFont->lfUnderline;
+		wlf.lfStrikeOut = v0->lpLogFont->lfStrikeOut;
+		wlf.lfCharSet = v0->lpLogFont->lfCharSet;
+		wlf.lfOutPrecision = v0->lpLogFont->lfOutPrecision;
+		wlf.lfClipPrecision = v0->lpLogFont->lfClipPrecision;
+		wlf.lfQuality = v0->lpLogFont->lfQuality;
+		wlf.lfPitchAndFamily = v0->lpLogFont->lfPitchAndFamily;
+		MtoW(wlf.lfFaceName, LF_FACESIZE, v0->lpLogFont->lfFaceName, -1);
+		TerminateStringW(wlf.lfFaceName, LF_FACESIZE);
+		a0.lpLogFont = &wlf;
 	}
 	else
-		pwlf = NULL;
-	a0.lpLogFont = pwlf;
+		a0.lpLogFont = nullptr;
 	a0.iPointSize = v0->iPointSize;
 	a0.Flags = v0->Flags;
 	a0.rgbColors = v0->rgbColors;
@@ -2304,28 +2304,26 @@ START_ROUTINE
 	r = ChooseFontW(&a0);
 	if(v0->lpLogFont)
 	{
-		v0->lpLogFont->lfHeight = pwlf->lfHeight;
-		v0->lpLogFont->lfWidth = pwlf->lfWidth;
-		v0->lpLogFont->lfEscapement = pwlf->lfEscapement;
-		v0->lpLogFont->lfOrientation = pwlf->lfOrientation;
-		v0->lpLogFont->lfWeight = pwlf->lfWeight;
-		v0->lpLogFont->lfItalic = pwlf->lfItalic;
-		v0->lpLogFont->lfUnderline = pwlf->lfUnderline;
-		v0->lpLogFont->lfStrikeOut = pwlf->lfStrikeOut;
-		v0->lpLogFont->lfCharSet = pwlf->lfCharSet;
-		v0->lpLogFont->lfOutPrecision = pwlf->lfOutPrecision;
-		v0->lpLogFont->lfClipPrecision = pwlf->lfClipPrecision;
-		v0->lpLogFont->lfQuality = pwlf->lfQuality;
-		v0->lpLogFont->lfPitchAndFamily = pwlf->lfPitchAndFamily;
-		WtoM(v0->lpLogFont->lfFaceName, LF_FACESIZE, pwlf->lfFaceName, -1);
+		v0->lpLogFont->lfHeight = wlf.lfHeight;
+		v0->lpLogFont->lfWidth = wlf.lfWidth;
+		v0->lpLogFont->lfEscapement = wlf.lfEscapement;
+		v0->lpLogFont->lfOrientation = wlf.lfOrientation;
+		v0->lpLogFont->lfWeight = wlf.lfWeight;
+		v0->lpLogFont->lfItalic = wlf.lfItalic;
+		v0->lpLogFont->lfUnderline = wlf.lfUnderline;
+		v0->lpLogFont->lfStrikeOut = wlf.lfStrikeOut;
+		v0->lpLogFont->lfCharSet = wlf.lfCharSet;
+		v0->lpLogFont->lfOutPrecision = wlf.lfOutPrecision;
+		v0->lpLogFont->lfClipPrecision = wlf.lfClipPrecision;
+		v0->lpLogFont->lfQuality = wlf.lfQuality;
+		v0->lpLogFont->lfPitchAndFamily = wlf.lfPitchAndFamily;
+		WtoM(v0->lpLogFont->lfFaceName, LF_FACESIZE, wlf.lfFaceName, -1);
 		TerminateStringM(v0->lpLogFont->lfFaceName, LF_FACESIZE);
 	}
 	v0->rgbColors = a0.rgbColors;
 	WtoM(v0->lpszStyle, LF_FACESIZE, pw1, -1);
 	TerminateStringM(v0->lpszStyle, LF_FACESIZE);
 	v0->nFontType = a0.nFontType;
-	if(pwlf)
-		free(pwlf);
 END_ROUTINE
 	FreeDuplicatedString(pw0);
 	FreeDuplicatedString(pw1);

--- a/socketwrapper.cpp
+++ b/socketwrapper.cpp
@@ -246,8 +246,7 @@ struct in6_addr inet6_addr(const char* cp)
 			}
 			else
 			{
-				Result.u.Word[i] = (USHORT)strtol(cp, &p, 16);
-				Result.u.Word[i] = ((Result.u.Word[i] & 0xff00) >> 8) | ((Result.u.Word[i] & 0x00ff) << 8);
+				Result.u.Word[i] = _byteswap_ushort((USHORT)strtol(cp, &p, 16));
 				if(strncmp(p, ":", 1) != 0 && strlen(p) > 0)
 				{
 					memcpy(&Result, &IN6ADDR_NONE, sizeof(struct in6_addr));

--- a/socketwrapper.cpp
+++ b/socketwrapper.cpp
@@ -99,35 +99,23 @@ DWORD WINAPI WSAAsyncGetHostByNameIPv6ThreadProc(LPVOID lpParameter)
 // ただしANSI用
 HANDLE WSAAsyncGetHostByNameIPv6(HWND hWnd, u_int wMsg, const char * name, char * buf, int buflen, short Family)
 {
-	HANDLE hResult;
-	GETHOSTBYNAMEDATA* pData;
-	hResult = NULL;
-	if(pData = (GETHOSTBYNAMEDATA*)malloc(sizeof(GETHOSTBYNAMEDATA)))
+	HANDLE hResult = nullptr;
+	GETHOSTBYNAMEDATA Data;
+	Data.hWnd = hWnd;
+	Data.wMsg = wMsg;
+	if(Data.name = (char*)malloc(sizeof(char) * (strlen(name) + 1)))
 	{
-		pData->hWnd = hWnd;
-		pData->wMsg = wMsg;
-		if(pData->name = (char*)malloc(sizeof(char) * (strlen(name) + 1)))
+		strcpy(Data.name, name);
+		Data.buf = buf;
+		Data.buflen = buflen;
+		Data.Family = Family;
+		if(Data.h = CreateThread(NULL, 0, WSAAsyncGetHostByNameIPv6ThreadProc, &Data, CREATE_SUSPENDED, NULL))
 		{
-			strcpy(pData->name, name);
-			pData->buf = buf;
-			pData->buflen = buflen;
-			pData->Family = Family;
-			if(pData->h = CreateThread(NULL, 0, WSAAsyncGetHostByNameIPv6ThreadProc, pData, CREATE_SUSPENDED, NULL))
-			{
-				ResumeThread(pData->h);
-				hResult = pData->h;
-			}
+			ResumeThread(Data.h);
+			hResult = Data.h;
 		}
 	}
-	if(!hResult)
-	{
-		if(pData)
-		{
-			if(pData->name)
-				free(pData->name);
-			free(pData);
-		}
-	}
+	if(!hResult) free(Data.name);
 	return hResult;
 }
 


### PR DESCRIPTION
確保する大きさがわかっている場合は単に配列を使うように。

b3fa7b5 にて`atoi_n`関数の仕様変更あり。