### PR TITLE
ファイルリストのパフォーマンス改善

### DIFF
--- a/common.h
+++ b/common.h
@@ -1323,6 +1323,11 @@ typedef struct filelist {
 	// ファイルアイコン表示対応
 	int ImageId;					/* アイコン画像番号 */
 	struct filelist *Next;
+	filelist() = default;
+	filelist(const char* file, char node, char link, LONGLONG size, int attr, FILETIME time, const char* owner, char infoExist) : Node{ node }, Link{ link }, Size{ size }, Attr{ attr }, Time{ time }, InfoExist{ infoExist } {
+		strcpy(File, file);
+		strcpy(Owner, owner);
+	}
 } FILELIST;
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -1803,8 +1803,18 @@ static LRESULT CALLBACK FtpWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 					break;
 
 				case LVN_ITEMCHANGED :
-					DispSelectedSpace();
-					MakeButtonsFocus();
+					{
+						// SetTimerによるとnIDEventが一致する既存のタイマーを置き換えるとのこと <https://msdn.microsoft.com/en-us/library/ms644906(v=vs.85).aspx>
+						// この通りであれば問題ない。ただしCWnd::SetTimerによると新たなタイマーが作成される（＝既存のタイマーを置き換えない）とのこと
+						// <https://docs.microsoft.com/ja-jp/cpp/mfc/reference/cwnd-class#settimer>
+						auto id = SetTimer(hWnd, 3, USER_TIMER_MINIMUM, [](auto hWnd, auto, auto, auto) {
+							DispSelectedSpace();
+							MakeButtonsFocus();
+							auto result = KillTimer(hWnd, 3);
+							assert(result);
+						});
+						assert(id == 3);
+					}
 					break;
 			}
 			break;

--- a/mbswrapper.cpp
+++ b/mbswrapper.cpp
@@ -1994,26 +1994,6 @@ END_ROUTINE
 	return r;
 }
 
-DWORD_PTR SHGetFileInfoM(LPCSTR pszPath, DWORD dwFileAttributes, SHFILEINFOA *psfi, UINT cbFileInfo, UINT uFlags)
-{
-	DWORD_PTR r = 0;
-	wchar_t* pw0 = NULL;
-	SHFILEINFOW wsfi;
-START_ROUTINE
-	pw0 = DuplicateMtoWMultiString(pszPath);
-	if((r = SHGetFileInfoW(pw0, dwFileAttributes, &wsfi, cbFileInfo, uFlags)) != 0)
-	{
-		psfi->hIcon = wsfi.hIcon;
-		psfi->iIcon = wsfi.iIcon;
-		psfi->dwAttributes = wsfi.dwAttributes;
-		WtoM(psfi->szDisplayName, MAX_PATH, wsfi.szDisplayName, -1);
-		WtoM(psfi->szTypeName, 80, wsfi.szTypeName, -1);
-	}
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
 BOOL AppendMenuM(HMENU hMenu, UINT uFlags, UINT_PTR uIDNewItem, LPCSTR lpNewItem)
 {
 	int r = 0;

--- a/mbswrapper.h
+++ b/mbswrapper.h
@@ -134,9 +134,6 @@ BOOL ShellExecuteExM(LPSHELLEXECUTEINFOA lpExecInfo);
 #undef SHFileOperation
 #define SHFileOperation SHFileOperationM
 int SHFileOperationM(LPSHFILEOPSTRUCTA lpFileOp);
-#undef SHGetFileInfo
-#define SHGetFileInfo SHGetFileInfoM
-DWORD_PTR SHGetFileInfoM(LPCSTR pszPath, DWORD dwFileAttributes, SHFILEINFOA *psfi, UINT cbFileInfo, UINT uFlags);
 #undef AppendMenu
 #define AppendMenu AppendMenuM
 BOOL AppendMenuM(HMENU hMenu, UINT uFlags, UINT_PTR uIDNewItem, LPCSTR lpNewItem);


### PR DESCRIPTION
- 一覧表示、ソート時
  - linked listで一覧作成 → std::vectorに変更しメモリ効率の改善
  - insertion sort → std::sortに変更しクイックソートを使用することでパフォーマンス改善
- ファイル選択時
 選択状態を１ファイルずつ変更している。変更に連動してLVN_ITEMCHANGED通知を受信し、そこでステータスバーの更新を行っていた。更にファイルサイズを集計し直していた。そのため、O(n^2)となっていた。 → タイマーを使用し10ms遅延させた。それによりステータスバーの更新は最後の１回のみに削減。