### PR TITLE
refactor remove-like functions, use fs::remove.

### DIFF
--- a/cache.cpp
+++ b/cache.cpp
@@ -310,12 +310,10 @@ void SaveCache(void)
 		DeleteCache();
 
 	MakeCacheFileName(998, Buf);
-	_unlink(Buf);
+	fs::remove(fs::u8path(Buf));
 
 	MakeCacheFileName(999, Buf);
-	_unlink(Buf);
-
-	return;
+	fs::remove(fs::u8path(Buf));
 }
 
 
@@ -367,41 +365,22 @@ void LoadCache(void)
 }
 
 
-/*----- キャッシュデータを全て削除する ----------------------------------------
-*
-*	Parameter
-*		なし
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
+// キャッシュデータを全て削除する
+void DeleteCache() {
+	if (ProgNum == 0)
+		fs::remove(fs::u8path(AskTmpFilePath()) / L"_ffftp.idx");
 
-void DeleteCache(void)
-{
-	char Buf[FMAX_PATH+1];
-	int i;
-
-	if(ProgNum == 0)
-	{
-		strcpy(Buf, AskTmpFilePath());
-		SetYenTail(Buf);
-		strcat(Buf, "_ffftp.idx");
-		_unlink(Buf);
-	}
-
-	for(i = 0; i <= TmpCacheEntry; i++)
-	{
+	char Buf[FMAX_PATH + 1];
+	for (auto i = 0; i <= TmpCacheEntry; i++) {
 		MakeCacheFileName(i, Buf);
-		_unlink(Buf);
+		fs::remove(fs::u8path(Buf));
 	}
 
 	MakeCacheFileName(998, Buf);
-	_unlink(Buf);
+	fs::remove(fs::u8path(Buf));
 
 	MakeCacheFileName(999, Buf);
-	_unlink(Buf);
-
-	return;
+	fs::remove(fs::u8path(Buf));
 }
 
 

--- a/local.cpp
+++ b/local.cpp
@@ -90,53 +90,19 @@ void DoLocalPWD(char *Buf)
 }
 
 
-/*----- ローカル側のディレクトリ削除 ------------------------------------------
-*
-*	Parameter
-*		char *Path : パス名
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void DoLocalRMD(char *Path)
-{
-#if 0
+// ローカル側のディレクトリ削除
+void DoLocalRMD(char *Path) {
 	SetTaskMsg(">>RMDIR %s", Path);
-	if(rmdir(Path) != 0)
-		SetTaskMsg(MSGJPN147);
-#else
-	SetTaskMsg(">>RMDIR %s", Path);
-
-	if(MoveFileToTrashCan(Path) != 0)
+	if (MoveFileToTrashCan(Path) != 0)
 		SetTaskMsg(MSGJPN148);
-#endif
-	return;
 }
 
 
-/*----- ローカル側のファイル削除 -----------------------------------------------
-*
-*	Parameter
-*		char *Path : パス名
-*
-*	Return Value
-*		なし
-*----------------------------------------------------------------------------*/
-
-void DoLocalDELE(char *Path)
-{
-#if 0
+// ローカル側のファイル削除
+void DoLocalDELE(char *Path) {
 	SetTaskMsg(">>DEL %s", Path);
-	if(DeleteFile(Path) != TRUE)
-		SetTaskMsg(MSGJPN149);
-#else
-	SetTaskMsg(">>DEL %s", Path);
-
-	if(MoveFileToTrashCan(Path) != 0)
+	if (MoveFileToTrashCan(Path) != 0)
 		SetTaskMsg(MSGJPN150);
-#endif
-	return;
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -2323,13 +2323,8 @@ static void ExitProc(HWND hWnd)
 	else
 		DeleteCache();
 
-	// 環境依存の不具合対策
 	GetAppTempPath(Tmp);
-	SetYenTail(Tmp);
-	strcat(Tmp, "file");
-	_rmdir(Tmp);
-	GetAppTempPath(Tmp);
-	_rmdir(Tmp);
+	fs::remove_all(fs::u8path(Tmp));
 
 	if(RasClose == YES)
 	{
@@ -3011,7 +3006,7 @@ static void DeleteAlltempFile(void)
 	Pos = TempFiles;
 	while(Pos != NULL)
 	{
-		DeleteFile(Pos->Fname);
+		fs::remove(fs::u8path(Pos->Fname));
 
 		Next = Pos->Next;
 		free(Pos->Fname);

--- a/mbswrapper.cpp
+++ b/mbswrapper.cpp
@@ -2094,18 +2094,6 @@ END_ROUTINE
 	return r;
 }
 
-BOOL DeleteFileM(LPCSTR lpFileName)
-{
-	BOOL r = FALSE;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(lpFileName, -1);
-	r = DeleteFileW(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
 BOOL CreateDirectoryM(LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes)
 {
 	BOOL r = FALSE;
@@ -2113,18 +2101,6 @@ BOOL CreateDirectoryM(LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttribu
 START_ROUTINE
 	pw0 = DuplicateMtoW(lpPathName, -1);
 	r = CreateDirectoryW(pw0, lpSecurityAttributes);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-BOOL RemoveDirectoryM(LPCSTR lpPathName)
-{
-	BOOL r = FALSE;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(lpPathName, -1);
-	r = RemoveDirectoryW(pw0);
 END_ROUTINE
 	FreeDuplicatedString(pw0);
 	return r;
@@ -2149,66 +2125,6 @@ int _mkdirM(const char * _Path)
 START_ROUTINE
 	pw0 = DuplicateMtoW(_Path, -1);
 	r = _wmkdir(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-int rmdirM(const char * _Path)
-{
-	int r = -1;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(_Path, -1);
-	r = _wrmdir(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-int _rmdirM(const char * _Path)
-{
-	int r = -1;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(_Path, -1);
-	r = _wrmdir(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-int removeM(const char * _Filename)
-{
-	int r = -1;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(_Filename, -1);
-	r = _wremove(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-int _removeM(const char * _Filename)
-{
-	int r = -1;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(_Filename, -1);
-	r = _wremove(pw0);
-END_ROUTINE
-	FreeDuplicatedString(pw0);
-	return r;
-}
-
-int _unlinkM(const char * _Filename)
-{
-	int r = -1;
-	wchar_t* pw0 = NULL;
-START_ROUTINE
-	pw0 = DuplicateMtoW(_Filename, -1);
-	r = _wunlink(pw0);
 END_ROUTINE
 	FreeDuplicatedString(pw0);
 	return r;

--- a/mbswrapper.h
+++ b/mbswrapper.h
@@ -152,36 +152,15 @@ BOOL sndPlaySoundM(LPCSTR pszSound, UINT fuSound);
 #undef MoveFile
 #define MoveFile MoveFileM
 BOOL MoveFileM(LPCSTR lpExistingFileName, LPCSTR lpNewFileName);
-#undef DeleteFile
-#define DeleteFile DeleteFileM
-BOOL DeleteFileM(LPCSTR lpFileName);
 #undef CreateDirectory
 #define CreateDirectory CreateDirectoryM
 BOOL CreateDirectoryM(LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
-#undef RemoveDirectory
-#define RemoveDirectory RemoveDirectoryM
-BOOL RemoveDirectoryM(LPCSTR lpPathName);
 #undef mkdir
 #define mkdir _mkdirM
 int mkdirM(const char * _Path);
 #undef _mkdir
 #define _mkdir _mkdirM
 int _mkdirM(const char * _Path);
-#undef rmdir
-#define rmdir rmdirM
-int rmdirM(const char * _Path);
-#undef _rmdir
-#define _rmdir _rmdirM
-int _rmdirM(const char * _Path);
-#undef remove
-#define remove removeM
-int removeM(const char * _Filename);
-#undef _remove
-#define _remove _removeM
-int _removeM(const char * _Filename);
-#undef _unlink
-#define _unlink _unlinkM
-int _unlinkM(const char * _Filename);
 #undef _mbslen
 #define _mbslen _mbslenM
 size_t _mbslenM(const unsigned char * _Str);

--- a/registry.cpp
+++ b/registry.cpp
@@ -1580,17 +1580,8 @@ void ClearRegistry(void)
 }
 
 
-// ポータブル版判定
-void ClearIni(void)
-{
-//	FILE *Strm;
-//	if((Strm = fopen(AskIniFilePath(), "rt")) != NULL)
-//	{
-//		fclose(Strm);
-//		MoveFileToTrashCan(AskIniFilePath());
-//	}
-	DeleteFile(AskIniFilePath());
-	return;
+void ClearIni() {
+	fs::remove(fs::u8path(AskIniFilePath()));
 }
 
 

--- a/taskwin.cpp
+++ b/taskwin.cpp
@@ -203,7 +203,7 @@ int SaveTaskMsg(char *Fname)
 			fclose(Strm);
 
 			if(Sts == FFFTP_FAIL)
-				_unlink(Fname);
+				fs::remove(fs::u8path(Fname));
 		}
 		free(Buf);
 	}


### PR DESCRIPTION
#61 でファイル削除を行うことになった。削除には`fs::remove`を使用したい。しかし、`remove`は`mbwrapper.h`で定義されるマクロである。そこで#10 の一環として`mbwrapper.h`で定義されるファイル削除関連の関数を一通り`fs::remove`または`fs::remove_all`へ移行する。