### PR TITLE
UPnP制御機能を既定で無効化する

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -232,7 +232,7 @@ int LocalKanjiCode = KANJI_SJIS;
 // 自動切断対策
 int NoopEnable = NO;
 // UPnP対応
-int UPnPEnabled = YES;
+int UPnPEnabled = NO;
 time_t LastDataConnectionTime = 0;
 // 全設定暗号化対応
 int EncryptAllSettings = NO;


### PR DESCRIPTION
UPnP制御機能が原因で接続できない事例が増えている

 - #44 接続先サーバーがPrivate IP
 - #44 VPN
 - IPv4 over IPv6

いずれも本来経由しないルーターに対してのUPnPポート制御を行い、当該ポートへconnectされるようftpサーバーにアドレスを通知してしまう。これにより`PORT`モードで接続に失敗する。